### PR TITLE
fix: use single click for tray on Linux

### DIFF
--- a/src/main/ipc/window-controls.ts
+++ b/src/main/ipc/window-controls.ts
@@ -39,7 +39,9 @@ function createTray() {
     tray?.setContextMenu(contextMenu);
   };
 
-  tray.on('double-click', () => {
+  const trayClickEvent = process.platform === 'linux' ? 'click' : 'double-click';
+
+  tray.on(trayClickEvent, () => {
     const window = getMainWindow();
     if (window) {
       window.show();


### PR DESCRIPTION
On Linux, the tray icon responds to a single click to show the window, while on Windows and macOS it uses double-click (which is the expected behavior on those platforms).