### PR TITLE
fix: issue with dark default mode in case system liquid glass active …

### DIFF
--- a/src/main/liquid-glass.ts
+++ b/src/main/liquid-glass.ts
@@ -40,7 +40,7 @@ export async function applyLiquidGlass(
     // Apply liquid glass effect
     const glassId = liquidGlass.addView(handle, {
       cornerRadius: 12,
-      tintColor: '#ffffff20', // Light tint for brighter glass look
+      tintColor: '#0a0f19cc', // Light tint for brighter glass look for dark theme specific
       opaque: false, // Ensure transparency
     });
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/electron/main';
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron';
 import { join } from 'path';
 import {
   applyLiquidGlass,
@@ -16,6 +16,11 @@ let liquidGlassId: number | null = null;
 
 export async function createMainWindow(): Promise<BrowserWindow> {
   console.log('[Window] Creating main window...');
+
+  // App is dark-only. Force the native appearance to dark so the macOS liquid
+  // glass material renders dark even when the system is in light mode (otherwise
+  // the transparent body shows a bright "light theme" through the glass).
+  nativeTheme.themeSource = 'dark';
 
   // Check if liquid glass is supported and get user preference
   const isSupported = supportsMacOSLiquidGlass();


### PR DESCRIPTION
### The problem

On macOS the native liquid glass material follows the system appearance (light/dark). When the user's Mac was in Light mode, the glass rendered bright. Because liquid-glass mode makes the app's body transparent (so the native material shows through), the whole UI looked like a broken light theme — even though the app is dark-only.

<img width="1264" height="764" alt="CleanShot 2026-06-03 at 19 11 28@2x" src="https://github.com/user-attachments/assets/09985b94-941c-4f9b-8bfc-7eb7f8e4b42c" />


#### After this fix:

<img width="1264" height="764" alt="CleanShot 2026-06-03 at 19 19 11@2x" src="https://github.com/user-attachments/assets/a7e1fb1f-b221-4023-8a6a-658b571a1cb3" />
